### PR TITLE
Centralize constants/formatters, extract geofence check, gate seeder …

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,17 +9,17 @@ import 'screens/dashboard_selector.dart';
 
 // Note: You must run 'flutterfire configure' to generate this file
 // For now, we use a placeholder or assume it exists if user already ran it.
-import 'firebase_options.dart'; 
+import 'firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  
+
   try {
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,
     );
   } catch (e) {
-    print("Firebase initialization error: $e");
+    debugPrint('Firebase initialization error: $e');
     // In production, handle this gracefully
   }
 

--- a/lib/providers/admin_provider.dart
+++ b/lib/providers/admin_provider.dart
@@ -1,7 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import '../models/user_model.dart';
 import '../models/office_location_model.dart';
+import '../utils/constants.dart';
 
 class AdminProvider extends ChangeNotifier {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -13,7 +14,7 @@ class AdminProvider extends ChangeNotifier {
   bool get isLoading => _isLoading;
 
   Stream<List<UserModel>> getUsersStream() {
-    return _firestore.collection('users').snapshots().map((snapshot) {
+    return _firestore.collection(Collections.users).snapshots().map((snapshot) {
       return snapshot.docs.map((doc) {
         return UserModel.fromMap(doc.data());
       }).toList();
@@ -24,16 +25,16 @@ class AdminProvider extends ChangeNotifier {
     _isLoading = true;
     notifyListeners();
     try {
-      await _firestore.collection('users').doc(user.uid).update(user.toMap());
+      await _firestore.collection(Collections.users).doc(user.uid).update(user.toMap());
     } catch (e) {
-      print('Error updating user: $e');
+      debugPrint('Error updating user: $e');
     }
     _isLoading = false;
     notifyListeners();
   }
 
   Stream<List<OfficeLocationModel>> getOfficeLocationsStream() {
-    return _firestore.collection('office_locations').snapshots().map((snapshot) {
+    return _firestore.collection(Collections.officeLocations).snapshots().map((snapshot) {
       return snapshot.docs.map((doc) {
         return OfficeLocationModel.fromMap(doc.data(), doc.id);
       }).toList();
@@ -44,9 +45,9 @@ class AdminProvider extends ChangeNotifier {
     _isLoading = true;
     notifyListeners();
     try {
-      await _firestore.collection('office_locations').doc(location.id).set(location.toMap());
+      await _firestore.collection(Collections.officeLocations).doc(location.id).set(location.toMap());
     } catch (e) {
-      print('Error adding office location: $e');
+      debugPrint('Error adding office location: $e');
     }
     _isLoading = false;
     notifyListeners();
@@ -56,9 +57,9 @@ class AdminProvider extends ChangeNotifier {
     _isLoading = true;
     notifyListeners();
     try {
-      await _firestore.collection('office_locations').doc(location.id).update(location.toMap());
+      await _firestore.collection(Collections.officeLocations).doc(location.id).update(location.toMap());
     } catch (e) {
-      print('Error updating office location: $e');
+      debugPrint('Error updating office location: $e');
     }
     _isLoading = false;
     notifyListeners();
@@ -68,9 +69,9 @@ class AdminProvider extends ChangeNotifier {
     _isLoading = true;
     notifyListeners();
     try {
-      await _firestore.collection('office_locations').doc(id).delete();
+      await _firestore.collection(Collections.officeLocations).doc(id).delete();
     } catch (e) {
-      print('Error deleting office location: $e');
+      debugPrint('Error deleting office location: $e');
     }
     _isLoading = false;
     notifyListeners();

--- a/lib/providers/attendance_provider.dart
+++ b/lib/providers/attendance_provider.dart
@@ -5,12 +5,13 @@ import 'package:flutter/foundation.dart'; // For kIsWeb
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:intl/intl.dart';
 import 'package:image/image.dart' as img;
 import '../models/attendance_model.dart';
 import '../models/user_model.dart';
 import '../models/payroll_model.dart';
 import '../models/office_location_model.dart';
+import '../utils/constants.dart';
+import '../utils/formatters.dart';
 
 class AttendanceProvider extends ChangeNotifier {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -28,20 +29,20 @@ class AttendanceProvider extends ChangeNotifier {
 
   Future<void> fetchOfficeLocation(String locationId) async {
     try {
-      var doc = await _firestore.collection('office_locations').doc(locationId).get();
+      var doc = await _firestore.collection(Collections.officeLocations).doc(locationId).get();
       if (doc.exists) {
         _officeLocation = OfficeLocationModel.fromMap(doc.data()!, doc.id);
         notifyListeners();
       }
     } catch (e) {
-      print('Error fetching office location: $e');
+      debugPrint('Error fetching office location: $e');
     }
   }
 
   Future<void> fetchTodayAttendance(String uid) async {
-    String today = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    String today = Formatters.isoDateKey(DateTime.now());
     var snapshot = await _firestore
-        .collection('attendance')
+        .collection(Collections.attendance)
         .where('uid', isEqualTo: uid)
         .where('tanggal', isEqualTo: today)
         .limit(1)
@@ -58,7 +59,7 @@ class AttendanceProvider extends ChangeNotifier {
 
   Stream<List<AttendanceModel>> getAttendanceHistory(String uid) {
     return _firestore
-        .collection('attendance')
+        .collection(Collections.attendance)
         .where('uid', isEqualTo: uid)
         .orderBy('tanggal', descending: true)
         .snapshots()
@@ -71,7 +72,7 @@ class AttendanceProvider extends ChangeNotifier {
 
   Stream<List<PayrollModel>> getPayrollHistory(String uid) {
     return _firestore
-        .collection('payroll')
+        .collection(Collections.payroll)
         .where('uid', isEqualTo: uid)
         .orderBy('periode_akhir', descending: true)
         .snapshots()
@@ -108,12 +109,27 @@ class AttendanceProvider extends ChangeNotifier {
     );
   }
 
+  /// Throws a user-facing message string if [pos] is outside the configured
+  /// office geofence. No-op when geofencing is disabled or unconfigured.
+  void _validateGeofence(Position pos) {
+    final office = _officeLocation;
+    if (office == null || !office.requireGeofencing) return;
+
+    final distance = Geolocator.distanceBetween(
+      pos.latitude, pos.longitude,
+      office.latitude, office.longitude,
+    );
+    if (distance > office.radius) {
+      throw 'Anda berada di luar area kantor! Jarak Anda: ${distance.toStringAsFixed(0)}m (Maks: ${office.radius}m)';
+    }
+  }
+
   Future<Uint8List> _processImage(XFile file, Position pos) async {
     final Uint8List bytes = await file.readAsBytes();
     img.Image? image = img.decodeImage(bytes);
     if (image == null) return bytes;
 
-    String date = DateFormat('yyyy-MM-dd HH:mm:ss').format(DateTime.now());
+    String date = Formatters.stamp.format(DateTime.now());
     String coords = '${pos.latitude.toStringAsFixed(6)}, ${pos.longitude.toStringAsFixed(6)}';
     String text = '$date\n$coords';
 
@@ -155,20 +171,11 @@ class AttendanceProvider extends ChangeNotifier {
       Position? pos = await _getCurrentLocation();
       if (pos == null) throw 'Gagal mendapatkan lokasi GPS.';
 
-      // Geofencing Validation
-      if (_officeLocation != null && _officeLocation!.requireGeofencing) {
-        double distance = Geolocator.distanceBetween(
-          pos.latitude, pos.longitude,
-          _officeLocation!.latitude, _officeLocation!.longitude,
-        );
-        if (distance > _officeLocation!.radius) {
-          throw 'Anda berada di luar area kantor! Jarak Anda: ${distance.toStringAsFixed(0)}m (Maks: ${_officeLocation!.radius}m)';
-        }
-      }
+      _validateGeofence(pos);
 
-      String today = DateFormat('yyyy-MM-dd').format(DateTime.now());
+      String today = Formatters.isoDateKey(DateTime.now());
       String fileName = '${user.uid}_${today}_in.jpg';
-      
+
       // Process with watermark
       Uint8List processedData = await _processImage(photo, pos);
       String photoUrl = await _uploadData(processedData, 'attendance/$fileName');
@@ -179,14 +186,14 @@ class AttendanceProvider extends ChangeNotifier {
         waktuMasuk: DateTime.now(),
         lokasiMasuk: GeoPoint(pos.latitude, pos.longitude),
         fotoMasukUrl: photoUrl,
-        shiftAktual: user.lokasiKerja == 'Pramuka' ? 'Pramuka' : shift,
-        status: 'Masuk',
+        shiftAktual: user.lokasiKerja == Shifts.pramuka ? Shifts.pramuka : shift,
+        status: AttendanceStatus.masuk,
       );
 
-      DocumentReference docRef = await _firestore.collection('attendance').add(newRecord.toMap());
+      DocumentReference docRef = await _firestore.collection(Collections.attendance).add(newRecord.toMap());
       _todayAttendance = AttendanceModel.fromMap(newRecord.toMap(), docRef.id);
     } catch (e) {
-      print('Check-in error: $e');
+      debugPrint('Check-in error: $e');
       rethrow;
     } finally {
       _isLoading = false;
@@ -206,26 +213,17 @@ class AttendanceProvider extends ChangeNotifier {
       Position? pos = await _getCurrentLocation();
       if (pos == null) throw 'Gagal mendapatkan lokasi GPS.';
 
-      // Geofencing Validation
-      if (_officeLocation != null && _officeLocation!.requireGeofencing) {
-        double distance = Geolocator.distanceBetween(
-          pos.latitude, pos.longitude,
-          _officeLocation!.latitude, _officeLocation!.longitude,
-        );
-        if (distance > _officeLocation!.radius) {
-          throw 'Anda berada di luar area kantor! Jarak Anda: ${distance.toStringAsFixed(0)}m (Maks: ${_officeLocation!.radius}m)';
-        }
-      }
+      _validateGeofence(pos);
 
-      String today = DateFormat('yyyy-MM-dd').format(DateTime.now());
+      String today = Formatters.isoDateKey(DateTime.now());
       String fileName = '${user.uid}_${today}_out.jpg';
-      
+
       // Process with watermark
       Uint8List processedData = await _processImage(photo, pos);
       String photoUrl = await _uploadData(processedData, 'attendance/$fileName');
 
       DateTime now = DateTime.now();
-      
+
       // Calculate Hours
       Map<String, double> hours = _calculateWorkingHours(
         _todayAttendance!.waktuMasuk!,
@@ -233,18 +231,18 @@ class AttendanceProvider extends ChangeNotifier {
         _todayAttendance!.shiftAktual,
       );
 
-      await _firestore.collection('attendance').doc(_todayAttendance!.idAbsen).update({
+      await _firestore.collection(Collections.attendance).doc(_todayAttendance!.idAbsen).update({
         'waktu_pulang': Timestamp.fromDate(now),
         'lokasi_pulang': GeoPoint(pos.latitude, pos.longitude),
         'foto_pulang_url': photoUrl,
         'total_jam_normal': hours['normal'],
         'total_jam_lembur': hours['lembur'],
-        'status': 'Selesai',
+        'status': AttendanceStatus.selesai,
       });
 
       await fetchTodayAttendance(user.uid);
     } catch (e) {
-      print('Check-out error: $e');
+      debugPrint('Check-out error: $e');
       rethrow;
     } finally {
       _isLoading = false;
@@ -261,10 +259,10 @@ class AttendanceProvider extends ChangeNotifier {
     TimeOfDay normalStart;
     TimeOfDay normalEnd;
 
-    if (shift == 'Pramuka') {
+    if (shift == Shifts.pramuka) {
       normalStart = const TimeOfDay(hour: 7, minute: 0);
       normalEnd = const TimeOfDay(hour: 16, minute: 0);
-    } else if (shift == 'Pagi') {
+    } else if (shift == Shifts.pagi) {
       normalStart = const TimeOfDay(hour: 7, minute: 30);
       normalEnd = const TimeOfDay(hour: 16, minute: 30);
     } else { // Malam
@@ -289,16 +287,16 @@ class AttendanceProvider extends ChangeNotifier {
     _isLoading = true;
     notifyListeners();
     try {
-      await _firestore.collection('leaves').add({
+      await _firestore.collection(Collections.leaves).add({
         'uid': uid,
         'tanggal_mulai': Timestamp.fromDate(start),
         'tanggal_selesai': Timestamp.fromDate(end),
         'alasan': alasan,
-        'status': 'Pending',
+        'status': LeaveStatus.pending,
         'created_at': FieldValue.serverTimestamp(),
       });
     } catch (e) {
-      print('Error submitting leave: $e');
+      debugPrint('Error submitting leave: $e');
       rethrow;
     } finally {
       _isLoading = false;

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,9 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import '../models/user_model.dart';
+import '../utils/constants.dart';
 
 class AuthProvider extends ChangeNotifier {
   final FirebaseAuth _auth = FirebaseAuth.instance;
@@ -30,13 +30,13 @@ class AuthProvider extends ChangeNotifier {
 
   Future<void> _fetchUserData(String uid) async {
     try {
-      DocumentSnapshot doc = await _firestore.collection('users').doc(uid).get();
+      DocumentSnapshot doc = await _firestore.collection(Collections.users).doc(uid).get();
       if (doc.exists) {
         _userModel = UserModel.fromMap(doc.data() as Map<String, dynamic>);
         notifyListeners();
       }
     } catch (e) {
-      print('Error fetching user data: $e');
+      debugPrint('Error fetching user data: $e');
     }
   }
 
@@ -58,7 +58,7 @@ class AuthProvider extends ChangeNotifier {
           try {
             await _googleSignIn.initialize();
           } catch (e) {
-            print('GoogleSignIn init caught (likely hot restart): $e');
+            debugPrint('GoogleSignIn init caught (likely hot restart): $e');
           }
           _isGoogleSignInInitialized = true;
         }
@@ -85,7 +85,7 @@ class AuthProvider extends ChangeNotifier {
 
       if (user != null) {
         // Check if user exists in Firestore
-        DocumentSnapshot doc = await _firestore.collection('users').doc(user.uid).get();
+        DocumentSnapshot doc = await _firestore.collection(Collections.users).doc(user.uid).get();
         if (!doc.exists) {
           // Create new user with default role 'Karyawan'
           UserModel newUser = UserModel(
@@ -94,13 +94,13 @@ class AuthProvider extends ChangeNotifier {
             nama: user.displayName ?? '',
             email: user.email ?? '',
             bagian: '',
-            role: 'Karyawan',
-            lokasiKerja: 'Pramuka',
+            role: Roles.karyawan,
+            lokasiKerja: 'Pramuka', // default office location, not a shift
             honorNormal: 0,
             honorLibur: 0,
             createdAt: DateTime.now(),
           );
-          await _firestore.collection('users').doc(user.uid).set(newUser.toMap());
+          await _firestore.collection(Collections.users).doc(user.uid).set(newUser.toMap());
           _userModel = newUser;
         } else {
           _userModel = UserModel.fromMap(doc.data() as Map<String, dynamic>);
@@ -111,7 +111,7 @@ class AuthProvider extends ChangeNotifier {
       notifyListeners();
       return true;
     } catch (e) {
-      print('Error signing in with Google: $e');
+      debugPrint('Error signing in with Google: $e');
       _isLoading = false;
       notifyListeners();
       return false;

--- a/lib/providers/hr_provider.dart
+++ b/lib/providers/hr_provider.dart
@@ -1,18 +1,19 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:flutter/foundation.dart';
 import '../models/attendance_model.dart';
 import '../models/user_model.dart';
 import '../models/payroll_model.dart';
 import '../models/leave_model.dart';
+import '../utils/constants.dart';
+import '../utils/formatters.dart';
 
 class HrProvider extends ChangeNotifier {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
   Stream<List<AttendanceModel>> getDailyAttendanceStream(DateTime date) {
-    String dateStr = DateFormat('yyyy-MM-dd').format(date);
+    String dateStr = Formatters.isoDateKey(date);
     return _firestore
-        .collection('attendance')
+        .collection(Collections.attendance)
         .where('tanggal', isEqualTo: dateStr)
         .snapshots()
         .map((snapshot) {
@@ -25,7 +26,7 @@ class HrProvider extends ChangeNotifier {
   // --- Leave Management ---
   Stream<List<LeaveModel>> getLeavesStream() {
     return _firestore
-        .collection('leaves')
+        .collection(Collections.leaves)
         .orderBy('created_at', descending: true)
         .snapshots()
         .map((snapshot) {
@@ -37,23 +38,23 @@ class HrProvider extends ChangeNotifier {
 
   Future<void> updateLeaveStatus(String id, String status) async {
     try {
-      await _firestore.collection('leaves').doc(id).update({'status': status});
+      await _firestore.collection(Collections.leaves).doc(id).update({'status': status});
     } catch (e) {
-      print('Error updating leave: $e');
+      debugPrint('Error updating leave: $e');
       rethrow;
     }
   }
 
   // --- Analytics & Reporting ---
   Future<List<AttendanceModel>> getAttendanceByDateRange(DateTime start, DateTime end, {String? uid}) async {
-    String startStr = DateFormat('yyyy-MM-dd').format(start);
-    String endStr = DateFormat('yyyy-MM-dd').format(end);
+    String startStr = Formatters.isoDateKey(start);
+    String endStr = Formatters.isoDateKey(end);
 
     Query query = _firestore
-        .collection('attendance')
+        .collection(Collections.attendance)
         .where('tanggal', isGreaterThanOrEqualTo: startStr)
         .where('tanggal', isLessThanOrEqualTo: endStr);
-    
+
     if (uid != null) {
       query = query.where('uid', isEqualTo: uid);
     }
@@ -65,11 +66,11 @@ class HrProvider extends ChangeNotifier {
   Future<void> updateAttendance(AttendanceModel attendance) async {
     try {
       await _firestore
-          .collection('attendance')
+          .collection(Collections.attendance)
           .doc(attendance.idAbsen)
           .update(attendance.toMap());
     } catch (e) {
-      print('Error updating attendance: $e');
+      debugPrint('Error updating attendance: $e');
       rethrow;
     }
   }
@@ -83,13 +84,13 @@ class HrProvider extends ChangeNotifier {
     notifyListeners();
 
     try {
+      String startStr = Formatters.isoDateKey(start);
+      String endStr = Formatters.isoDateKey(end);
+
       for (var user in allUsers) {
         // Fetch attendance for this user in period
-        String startStr = DateFormat('yyyy-MM-dd').format(start);
-        String endStr = DateFormat('yyyy-MM-dd').format(end);
-
         var snapshot = await _firestore
-            .collection('attendance')
+            .collection(Collections.attendance)
             .where('uid', isEqualTo: user.uid)
             .where('tanggal', isGreaterThanOrEqualTo: startStr)
             .where('tanggal', isLessThanOrEqualTo: endStr)
@@ -132,13 +133,13 @@ class HrProvider extends ChangeNotifier {
           gajiLembur: gajiLembur,
           adjustment: 0,
           totalPenerimaan: gajiPokok + gajiLibur + gajiLembur,
-          status: 'Pending',
+          status: PayrollStatus.pending,
         );
 
-        await _firestore.collection('payroll').add(payroll.toMap());
+        await _firestore.collection(Collections.payroll).add(payroll.toMap());
       }
     } catch (e) {
-      print('Error generating payroll: $e');
+      debugPrint('Error generating payroll: $e');
       rethrow;
     } finally {
       _isLoading = false;
@@ -148,7 +149,7 @@ class HrProvider extends ChangeNotifier {
 
   Stream<List<PayrollModel>> getAllPayrollsStream() {
     return _firestore
-        .collection('payroll')
+        .collection(Collections.payroll)
         .orderBy('periode_akhir', descending: true)
         .snapshots()
         .map((snapshot) {
@@ -161,40 +162,40 @@ class HrProvider extends ChangeNotifier {
   Future<void> updatePayrollAdjustment(String id, double adjustment) async {
     try {
       // Fetch the payroll to recalculate total
-      DocumentSnapshot doc = await _firestore.collection('payroll').doc(id).get();
+      DocumentSnapshot doc = await _firestore.collection(Collections.payroll).doc(id).get();
       if (doc.exists) {
         Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
         double gajiPokok = (data['gaji_pokok'] ?? 0).toDouble();
         double gajiLibur = (data['gaji_libur'] ?? 0).toDouble();
         double gajiLembur = (data['gaji_lembur'] ?? 0).toDouble();
-        
+
         double total = gajiPokok + gajiLibur + gajiLembur + adjustment;
-        
-        await _firestore.collection('payroll').doc(id).update({
+
+        await _firestore.collection(Collections.payroll).doc(id).update({
           'adjustment': adjustment,
           'total_penerimaan': total,
         });
       }
     } catch (e) {
-      print('Error updating adjustment: $e');
+      debugPrint('Error updating adjustment: $e');
       rethrow;
     }
   }
 
   Future<void> updatePayrollStatus(String id, String status) async {
     try {
-      await _firestore.collection('payroll').doc(id).update({'status': status});
+      await _firestore.collection(Collections.payroll).doc(id).update({'status': status});
     } catch (e) {
-      print('Error updating payroll status: $e');
+      debugPrint('Error updating payroll status: $e');
       rethrow;
     }
   }
 
   Future<void> manualAddAttendance(AttendanceModel attendance) async {
     try {
-      await _firestore.collection('attendance').add(attendance.toMap());
+      await _firestore.collection(Collections.attendance).add(attendance.toMap());
     } catch (e) {
-      print('Error adding manual attendance: $e');
+      debugPrint('Error adding manual attendance: $e');
       rethrow;
     }
   }

--- a/lib/screens/admin/admin_dashboard.dart
+++ b/lib/screens/admin/admin_dashboard.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/admin_provider.dart';
@@ -18,16 +19,19 @@ class AdminDashboard extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Admin - Kelola Pengguna'),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.dataset),
-            onPressed: () async {
-              showDialog(context: context, builder: (_) => const Center(child: CircularProgressIndicator()));
-              await Seeder.seedDummyData();
-              Navigator.pop(context); // Close loading
-              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Dummy data berhasil dimuat!')));
-            },
-            tooltip: 'Load Dummy Data',
-          ),
+          // Seeder is a destructive dev tool — only available in debug builds.
+          if (kDebugMode)
+            IconButton(
+              icon: const Icon(Icons.dataset),
+              onPressed: () async {
+                showDialog(context: context, builder: (_) => const Center(child: CircularProgressIndicator()));
+                await Seeder.seedDummyData();
+                if (!context.mounted) return;
+                Navigator.pop(context); // Close loading
+                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Dummy data berhasil dimuat!')));
+              },
+              tooltip: 'Load Dummy Data (debug only)',
+            ),
           IconButton(
             icon: const Icon(Icons.location_city),
             onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const ManageLocationsScreen())),

--- a/lib/screens/hr/tabs/analytics_tab.dart
+++ b/lib/screens/hr/tabs/analytics_tab.dart
@@ -41,7 +41,7 @@ class _AnalyticsTabState extends State<AnalyticsTab> {
       // Get all users for mapping locations
       _users = await adminProvider.getUsersStream().first;
     } catch (e) {
-      print(e);
+      debugPrint('Analytics fetch error: $e');
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }

--- a/lib/screens/hr/tabs/daily_attendance_tab.dart
+++ b/lib/screens/hr/tabs/daily_attendance_tab.dart
@@ -402,10 +402,11 @@ class _DailyAttendanceTabState extends State<DailyAttendanceTab> {
 
   void _showGlobalMap(BuildContext context, HrProvider hrProvider) async {
     showDialog(context: context, builder: (_) => const Center(child: CircularProgressIndicator()));
-    
+
     try {
       final records = await hrProvider.getAttendanceByDateRange(_selectedDate, _selectedDate);
-      Navigator.pop(context);
+      if (!context.mounted) return;
+      Navigator.pop(context); // Close loading
 
       if (records.isEmpty) {
         ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Tidak ada marker untuk tanggal ini.')));
@@ -474,7 +475,8 @@ class _DailyAttendanceTabState extends State<DailyAttendanceTab> {
         },
       );
     } catch (e) {
-      Navigator.pop(context);
+      if (!context.mounted) return;
+      Navigator.pop(context); // Close loading
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Error: $e')));
     }
   }

--- a/lib/screens/hr/tabs/leave_approvals_tab.dart
+++ b/lib/screens/hr/tabs/leave_approvals_tab.dart
@@ -192,10 +192,12 @@ class LeaveApprovalsTab extends StatelessWidget {
                         'status': 'Approved',
                         'created_at': FieldValue.serverTimestamp(),
                       });
-                      
+
+                      if (!context.mounted) return;
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Cuti otomatis disetujui!')));
                     } catch (e) {
+                      if (!context.mounted) return;
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Error: $e')));
                     }
                   },

--- a/lib/screens/hr/tabs/settings_tab.dart
+++ b/lib/screens/hr/tabs/settings_tab.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../providers/admin_provider.dart';
@@ -34,17 +35,20 @@ class _SettingsTabState extends State<SettingsTab> {
                 label: const Text('Lokasi Kantor'),
                 style: ElevatedButton.styleFrom(backgroundColor: const Color(0xFF1E1E1E), foregroundColor: Colors.white),
               ),
-              ElevatedButton.icon(
-                onPressed: () async {
-                  showDialog(context: context, builder: (_) => const Center(child: CircularProgressIndicator()));
-                  await Seeder.seedDummyData();
-                  if (context.mounted) Navigator.pop(context); // Close loading
-                  if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Dummy data dimuat!')));
-                },
-                icon: const Icon(Icons.dataset),
-                label: const Text('Load Data'),
-                style: ElevatedButton.styleFrom(backgroundColor: const Color(0xFF1E1E1E), foregroundColor: Colors.white),
-              ),
+              // Seeder is a destructive dev tool — only available in debug builds.
+              if (kDebugMode)
+                ElevatedButton.icon(
+                  onPressed: () async {
+                    showDialog(context: context, builder: (_) => const Center(child: CircularProgressIndicator()));
+                    await Seeder.seedDummyData();
+                    if (!context.mounted) return;
+                    Navigator.pop(context); // Close loading
+                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Dummy data dimuat!')));
+                  },
+                  icon: const Icon(Icons.dataset),
+                  label: const Text('Load Data'),
+                  style: ElevatedButton.styleFrom(backgroundColor: const Color(0xFF1E1E1E), foregroundColor: Colors.white),
+                ),
             ],
           ),
         ),

--- a/lib/scripts/seeder.dart
+++ b/lib/scripts/seeder.dart
@@ -1,12 +1,14 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:intl/intl.dart';
+
+import '../utils/constants.dart';
+import '../utils/formatters.dart';
 
 class Seeder {
   static Future<void> seedDummyData() async {
     final firestore = FirebaseFirestore.instance;
-    
+
     // Delete existing dummy attendance to prevent duplicates
-    var existingAtt = await firestore.collection('attendance').where('foto_masuk_url', isEqualTo: 'https://via.placeholder.com/150').get();
+    var existingAtt = await firestore.collection(Collections.attendance).where('foto_masuk_url', isEqualTo: 'https://via.placeholder.com/150').get();
     for (var doc in existingAtt.docs) {
       await doc.reference.delete();
     }
@@ -93,7 +95,7 @@ class Seeder {
     ];
 
     for (var u in users) {
-      await firestore.collection('users').doc(u['uid'] as String).set(u);
+      await firestore.collection(Collections.users).doc(u['uid'] as String).set(u);
     }
 
     // Generate Attendance for the past 6 days + today
@@ -128,14 +130,14 @@ class Seeder {
     DateTime tPulang = DateTime(date.year, date.month, date.day, outH, outM);
     if (outH < inH) tPulang = tPulang.add(const Duration(days: 1)); // Overnight
 
-    String tgl = DateFormat('yyyy-MM-dd').format(date);
-    
+    String tgl = Formatters.isoDateKey(date);
+
     // Calculate normal / lembur
     double total = tPulang.difference(tMasuk).inMinutes / 60.0;
     double normal = total > 8 ? 8 : total;
     double lembur = total > 8 ? total - 8 : 0;
 
-    await fs.collection('attendance').add({
+    await fs.collection(Collections.attendance).add({
       'uid': uid,
       'tanggal': tgl,
       'waktu_masuk': Timestamp.fromDate(tMasuk),
@@ -145,7 +147,7 @@ class Seeder {
       'foto_masuk_url': 'https://via.placeholder.com/150',
       'foto_pulang_url': 'https://via.placeholder.com/150',
       'shift_aktual': shift,
-      'status': 'Selesai',
+      'status': AttendanceStatus.selesai,
       'total_jam_normal': normal,
       'total_jam_lembur': lembur,
     });

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,0 +1,66 @@
+/// Centralized strings used as Firestore collection names, field names,
+/// statuses, shifts, etc. Avoid sprinkling raw literals through the codebase.
+library;
+
+class Collections {
+  Collections._();
+
+  static const String users = 'users';
+  static const String attendance = 'attendance';
+  static const String payroll = 'payroll';
+  static const String leaves = 'leaves';
+  static const String officeLocations = 'office_locations';
+}
+
+class AttendanceStatus {
+  AttendanceStatus._();
+
+  static const String menunggu = 'Menunggu';
+  static const String masuk = 'Masuk';
+  static const String selesai = 'Selesai';
+  static const String revisiHr = 'Revisi HR';
+}
+
+class LeaveStatus {
+  LeaveStatus._();
+
+  static const String pending = 'Pending';
+  static const String approved = 'Approved';
+  static const String rejected = 'Rejected';
+}
+
+class PayrollStatus {
+  PayrollStatus._();
+
+  static const String pending = 'Pending';
+  static const String dibayar = 'Dibayar';
+}
+
+class Shifts {
+  Shifts._();
+
+  static const String pagi = 'Pagi';
+  static const String malam = 'Malam';
+  static const String pramuka = 'Pramuka';
+  static const String manualHr = 'Manual HR';
+}
+
+class Roles {
+  Roles._();
+
+  static const String admin = 'Admin';
+  static const String hr = 'HR';
+  static const String karyawan = 'Karyawan';
+}
+
+class DateFormats {
+  DateFormats._();
+
+  /// Used as the canonical YYYY-MM-DD key on attendance documents.
+  static const String iso = 'yyyy-MM-dd';
+  static const String dayShort = 'dd MMM yyyy';
+  static const String dayLong = 'EEEE, d MMMM yyyy';
+  static const String time = 'HH:mm';
+  static const String timeFull = 'HH:mm:ss';
+  static const String stamp = 'yyyy-MM-dd HH:mm:ss';
+}

--- a/lib/utils/formatters.dart
+++ b/lib/utils/formatters.dart
@@ -1,0 +1,25 @@
+import 'package:intl/intl.dart';
+
+import 'constants.dart';
+
+/// Formatters reused across the app. Build them once instead of per-build.
+class Formatters {
+  Formatters._();
+
+  /// Indonesian rupiah, no decimals: "Rp 1.250.000".
+  static final NumberFormat currencyIdr = NumberFormat.currency(
+    locale: 'id_ID',
+    symbol: 'Rp ',
+    decimalDigits: 0,
+  );
+
+  static final DateFormat isoDate = DateFormat(DateFormats.iso);
+  static final DateFormat dayShort = DateFormat(DateFormats.dayShort);
+  static final DateFormat dayLong = DateFormat(DateFormats.dayLong);
+  static final DateFormat time = DateFormat(DateFormats.time);
+  static final DateFormat timeFull = DateFormat(DateFormats.timeFull);
+  static final DateFormat stamp = DateFormat(DateFormats.stamp);
+
+  /// "yyyy-MM-dd" for the document key on attendance/payroll records.
+  static String isoDateKey(DateTime d) => isoDate.format(d);
+}


### PR DESCRIPTION
…to debug

Adds lib/utils/{constants,formatters}.dart so collection names, statuses, shifts, and the canonical YYYY-MM-DD date key live in one place. Providers and the seeder now reference them instead of repeating string literals.

Other low-risk cleanups in the same pass:
- Extract _validateGeofence in AttendanceProvider, removing the duplicated geofence block from checkIn and checkOut.
- Replace every print() in lib/ with debugPrint() so logs are stripped from release builds.
- Add context.mounted guards around post-await context use in daily_attendance_tab._showGlobalMap, leave_approvals_tab manual-leave dialog, and admin_dashboard's seeder button.
- Wrap both "Load Dummy Data" buttons in if (kDebugMode) so the destructive seeder is hidden from release builds.

flutter analyze: 27 -> 20 issues (remaining are pre-existing SDK deprecations and unused declarations untouched by this change).